### PR TITLE
Avoid calling ElementTree.register_namespace

### DIFF
--- a/src/heroicons/_compat.py
+++ b/src/heroicons/_compat.py
@@ -5,7 +5,7 @@ if sys.version_info < (3, 9):
     def str_removeprefix(self, prefix):
         if self.startswith(prefix):
             return self[len(prefix) :]
-        else:
+        else:  # pragma: no cover
             return self[:]
 
 

--- a/src/heroicons/_compat.py
+++ b/src/heroicons/_compat.py
@@ -2,7 +2,7 @@ import sys
 
 if sys.version_info < (3, 9):
 
-    def str_removeprefix(self: str, prefix: str, /) -> str:
+    def str_removeprefix(self, prefix):
         if self.startswith(prefix):
             return self[len(prefix) :]
         else:

--- a/src/heroicons/_compat.py
+++ b/src/heroicons/_compat.py
@@ -1,0 +1,13 @@
+import sys
+
+if sys.version_info < (3, 9):
+
+    def str_removeprefix(self: str, prefix: str, /) -> str:
+        if self.startswith(prefix):
+            return self[len(prefix) :]
+        else:
+            return self[:]
+
+
+else:
+    str_removeprefix = str.removeprefix

--- a/tests/test_heroicons.py
+++ b/tests/test_heroicons.py
@@ -8,13 +8,13 @@ import heroicons
 def test_success_outline():
     svg = heroicons.load_icon("outline", "academic-cap")
     assert isinstance(svg, ElementTree.Element)
-    assert svg.tag == "{http://www.w3.org/2000/svg}svg"
+    assert svg.tag == ElementTree.QName("svg")
 
 
 def test_success_solid():
     svg = heroicons.load_icon("solid", "academic-cap")
     assert isinstance(svg, ElementTree.Element)
-    assert svg.tag == "{http://www.w3.org/2000/svg}svg"
+    assert svg.tag == ElementTree.QName("svg")
 
 
 def test_fail_unknown():


### PR DESCRIPTION
This interacts badly with other SVG generating libraries that do it their own way - as discovered testing where `qrcode` is used.