### PR TITLE
Drop importlib_resources requirement

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,5 @@
 coverage
 django
-importlib_resources ; python_version < "3.7"
 jinja2
 pytest
 pytest-randomly

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,6 @@ package_dir=
     =src
 packages = find:
 include_package_data = True
-install_requires =
-    importlib_resources >= 1.3 ; python_version < "3.7"
 python_requires = >=3.7
 zip_safe = False
 


### PR DESCRIPTION
Included in Python 3.7+