### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/download_heroicons.py
+++ b/download_heroicons.py
@@ -8,7 +8,8 @@ import argparse
 import os
 import subprocess
 from io import BytesIO
-from zipfile import ZIP_DEFLATED, ZipFile
+from zipfile import ZIP_DEFLATED
+from zipfile import ZipFile
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/heroicons/__init__.py
+++ b/src/heroicons/__init__.py
@@ -6,7 +6,8 @@ from copy import deepcopy
 from xml.etree import ElementTree
 from zipfile import ZipFile
 
-from heroicons._compat import open_binary, str_removeprefix
+from heroicons._compat import open_binary
+from heroicons._compat import str_removeprefix
 
 
 class IconDoesNotExist(Exception):

--- a/src/heroicons/templatetags/heroicons.py
+++ b/src/heroicons/templatetags/heroicons.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django import template
-from django.utils.safestring import SafeString, mark_safe
+from django.utils.safestring import mark_safe
+from django.utils.safestring import SafeString
 
 import heroicons
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -5,7 +5,8 @@ from typing import Any
 
 import django
 from django.conf import settings
-from django.template import Context, Template
+from django.template import Context
+from django.template import Template
 
 settings.configure(
     ROOT_URLCONF=__name__,  # Make this module the urlconf

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import sys
 
-from jinja2 import DictLoader, Environment
+from jinja2 import DictLoader
+from jinja2 import Environment
 
-from heroicons.jinja import heroicon_mini, heroicon_outline, heroicon_solid
+from heroicons.jinja import heroicon_mini
+from heroicons.jinja import heroicon_outline
+from heroicons.jinja import heroicon_solid
 
 
 def make_environment(index_template: str) -> Environment:


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
