### PR TITLE
Drop Django 4.2 to 5.1 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,6 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies:
-    - django-stubs==5.1.2
+    - django-stubs==6.0.5
     - jinja2
     - markupsafe

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Drop Django 4.2 to 5.1 support.
+
 2.14.0 (2026-03-08)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Requirements
 
 Python 3.10 to 3.14 supported.
 
-Django 4.2 to 6.0 supported.
+Django 5.2 to 6.0 supported.
 
 Usage
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ authors = [
 requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
-  "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
@@ -54,18 +51,12 @@ test = [
   "pytest>=9",
   "pytest-randomly",
 ]
-django42 = [ "django>=4.2a1,<5; python_version>='3.8'" ]
-django50 = [ "django>=5a1,<5.1; python_version>='3.10'" ]
-django51 = [ "django>=5.1a1,<5.2; python_version>='3.10'" ]
 django52 = [ "django>=5.2a1,<6; python_version>='3.10'" ]
 django60 = [ "django>=6a1,<6.1; python_version>='3.12'" ]
 
 [tool.uv]
 conflicts = [
   [
-    { group = "django42" },
-    { group = "django50" },
-    { group = "django51" },
     { group = "django52" },
     { group = "django60" },
   ],

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@ requires =
     tox>=4.2
 env_list =
     py314-django{60, 52}
-    py313-django{60, 52, 51}
-    py312-django{60, 52, 51, 50, 42}
-    py311-django{52, 51, 50, 42}
-    py310-django{52, 51, 50, 42}
+    py313-django{60, 52}
+    py312-django{60, 52}
+    py311-django{52}
+    py310-django{52}
 
 [testenv]
 runner = uv-venv-lock-runner

--- a/uv.lock
+++ b/uv.lock
@@ -2,19 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60'",
-    "python_full_version < '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60'",
-    "extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
-    "extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
-    "extra != 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
-    "extra == 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
-    "python_full_version >= '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
-    "python_full_version < '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
+    "python_full_version >= '3.12' and extra != 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60'",
+    "python_full_version < '3.12' and extra != 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60'",
+    "extra == 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
+    "python_full_version >= '3.12' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
+    "python_full_version < '3.12' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
 ]
 conflicts = [[
-    { package = "heroicons", group = "django42" },
-    { package = "heroicons", group = "django50" },
-    { package = "heroicons", group = "django51" },
     { package = "heroicons", group = "django52" },
     { package = "heroicons", group = "django60" },
 ]]
@@ -24,7 +18,7 @@ name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
@@ -155,49 +149,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-]
-
-[[package]]
-name = "django"
-version = "4.2.30"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref", marker = "extra == 'group-9-heroicons-django42' or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "sqlparse", marker = "extra == 'group-9-heroicons-django42' or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "tzdata", marker = "(sys_platform == 'win32' and extra == 'group-9-heroicons-django42') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/b5/f1a53dc68da6429d6e0345bb848161e2381a2e9f02700148911e8582c2b3/django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c", size = 10468707, upload-time = "2026-04-07T14:05:45.57Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/b7/a7c96f239cf91313a6589233fed55111c7063b26683b226802732c455dbc/django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65", size = 7997231, upload-time = "2026-04-07T14:05:38.241Z" },
-]
-
-[[package]]
-name = "django"
-version = "5.0.14"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref", marker = "extra == 'group-9-heroicons-django50' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "sqlparse", marker = "extra == 'group-9-heroicons-django50' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "tzdata", marker = "(sys_platform == 'win32' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/cc0205045386b5be8eecb15a95f290383d103f0db5f7e34f93dcc340d5b0/Django-5.0.14.tar.gz", hash = "sha256:29019a5763dbd48da1720d687c3522ef40d1c61be6fb2fad27ed79e9f655bc11", size = 10644306, upload-time = "2025-04-02T11:24:41.396Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/93/eabde8789f41910845567ebbff5aacd52fd80e54c934ce15b83d5f552d2c/Django-5.0.14-py3-none-any.whl", hash = "sha256:e762bef8629ee704de215ebbd32062b84f4e56327eed412e5544f6f6eb1dfd74", size = 8185934, upload-time = "2025-04-02T11:24:36.888Z" },
-]
-
-[[package]]
-name = "django"
-version = "5.1.15"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref", marker = "extra == 'group-9-heroicons-django51' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60')" },
-    { name = "sqlparse", marker = "extra == 'group-9-heroicons-django51' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60')" },
-    { name = "tzdata", marker = "(sys_platform == 'win32' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/45/1ac68964193cfcc0b0912a0f68025d5bdb54f71ba7b8716e85b959874bd0/django-5.1.15.tar.gz", hash = "sha256:46a356b5ff867bece73fc6365e081f21c569973403ee7e9b9a0316f27d0eb947", size = 10719662, upload-time = "2025-12-02T14:01:31.931Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/79/372e091f0eba4ddb8228245ccd1baaa140e9658711f5e3a0056e540b4c1e/django-5.1.15-py3-none-any.whl", hash = "sha256:117871e58d6eda37f09870b7d73a3d66567b03aecd515b386b1751177c413432", size = 8260901, upload-time = "2025-12-02T14:01:27.352Z" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
 ]
 
 [[package]]
@@ -205,14 +157,14 @@ name = "django"
 version = "5.2.14"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60'",
-    "extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
-    "python_full_version < '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
+    "python_full_version < '3.12' and extra != 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60'",
+    "extra == 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
+    "python_full_version < '3.12' and extra != 'group-9-heroicons-django52' and extra != 'group-9-heroicons-django60'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "(python_full_version < '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51') or extra == 'group-9-heroicons-django52' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60')" },
-    { name = "sqlparse", marker = "(python_full_version < '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51') or extra == 'group-9-heroicons-django52' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60')" },
-    { name = "tzdata", marker = "(python_full_version < '3.12' and sys_platform == 'win32' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51') or (sys_platform == 'win32' and extra == 'group-9-heroicons-django52') or (sys_platform != 'win32' and extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60')" },
+    { name = "asgiref", marker = "python_full_version < '3.12' or extra == 'group-9-heroicons-django52'" },
+    { name = "sqlparse", marker = "python_full_version < '3.12' or extra == 'group-9-heroicons-django52'" },
+    { name = "tzdata", marker = "(python_full_version < '3.12' and sys_platform == 'win32') or (sys_platform == 'win32' and extra == 'group-9-heroicons-django52') or (sys_platform != 'win32' and extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
 wheels = [
@@ -227,9 +179,9 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "(python_full_version >= '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "sqlparse", marker = "(python_full_version >= '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "tzdata", marker = "(python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "asgiref", marker = "(python_full_version >= '3.12' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "sqlparse", marker = "(python_full_version >= '3.12' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "tzdata", marker = "(python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
 wheels = [
@@ -241,7 +193,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12' or (python_full_version == '3.12.*' and extra == 'group-9-heroicons-django42') or (python_full_version == '3.12.*' and extra == 'group-9-heroicons-django50') or (python_full_version == '3.12.*' and extra == 'group-9-heroicons-django51') or (python_full_version == '3.12.*' and extra == 'group-9-heroicons-django52') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (python_full_version == '3.12.*' and extra == 'group-9-heroicons-django52') or (python_full_version >= '3.13' and extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -255,26 +207,14 @@ source = { editable = "." }
 
 [package.optional-dependencies]
 django = [
-    { name = "django", version = "4.2.30", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-9-heroicons-django42' or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "django", version = "5.0.14", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-9-heroicons-django50' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "django", version = "5.1.15", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-9-heroicons-django51' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60')" },
-    { name = "django", version = "5.2.14", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51') or extra == 'group-9-heroicons-django52' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60')" },
-    { name = "django", version = "6.0.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra != 'group-9-heroicons-django42' and extra != 'group-9-heroicons-django50' and extra != 'group-9-heroicons-django51' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "django", version = "5.2.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or extra == 'group-9-heroicons-django52'" },
+    { name = "django", version = "6.0.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra != 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
 ]
 jinja = [
     { name = "jinja2" },
 ]
 
 [package.dev-dependencies]
-django42 = [
-    { name = "django", version = "4.2.30", source = { registry = "https://pypi.org/simple" } },
-]
-django50 = [
-    { name = "django", version = "5.0.14", source = { registry = "https://pypi.org/simple" } },
-]
-django51 = [
-    { name = "django", version = "5.1.15", source = { registry = "https://pypi.org/simple" } },
-]
 django52 = [
     { name = "django", version = "5.2.14", source = { registry = "https://pypi.org/simple" } },
 ]
@@ -296,9 +236,6 @@ requires-dist = [
 provides-extras = ["django", "jinja"]
 
 [package.metadata.requires-dev]
-django42 = [{ name = "django", marker = "python_full_version >= '3.8'", specifier = ">=4.2a1,<5" }]
-django50 = [{ name = "django", marker = "python_full_version >= '3.10'", specifier = ">=5a1,<5.1" }]
-django51 = [{ name = "django", marker = "python_full_version >= '3.10'", specifier = ">=5.1a1,<5.2" }]
 django52 = [{ name = "django", marker = "python_full_version >= '3.10'", specifier = ">=5.2a1,<6" }]
 django60 = [{ name = "django", marker = "python_full_version >= '3.12'", specifier = ">=6a1,<6.1" }]
 test = [
@@ -446,13 +383,13 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django50') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django42' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django51') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django50' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django52') or (extra == 'group-9-heroicons-django51' and extra == 'group-9-heroicons-django60') or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-9-heroicons-django52' and extra == 'group-9-heroicons-django60')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [


### PR DESCRIPTION
These versions are all EOL since April.
